### PR TITLE
[UI] DetailView에 있는 amountStepper에 action 추가하기

### DIFF
--- a/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		024D59D428112409007E2727 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D328112409007E2727 /* PaddingLabel.swift */; };
 		024D59D728123C25007E2727 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D628123C25007E2727 /* UIColor+.swift */; };
 		024D59D92812430F007E2727 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D82812430F007E2727 /* DetailView.swift */; };
+		024D59DD28164188007E2727 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59DC28164188007E2727 /* String+.swift */; };
 		0279B33F280FDB9E00DDBA6E /* DishCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0279B33D280FDB9E00DDBA6E /* DishCell.swift */; };
 		0279B340280FDB9E00DDBA6E /* DishCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0279B33E280FDB9E00DDBA6E /* DishCell.xib */; };
 		02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F119C928102B0E00B9B6A7 /* DetailViewController.swift */; };
@@ -78,6 +79,7 @@
 		024D59D328112409007E2727 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		024D59D628123C25007E2727 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		024D59D82812430F007E2727 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		024D59DC28164188007E2727 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		0279B33D280FDB9E00DDBA6E /* DishCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DishCell.swift; sourceTree = "<group>"; };
 		0279B33E280FDB9E00DDBA6E /* DishCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DishCell.xib; sourceTree = "<group>"; };
 		02F119C928102B0E00B9B6A7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 			isa = PBXGroup;
 			children = (
 				024D59D628123C25007E2727 /* UIColor+.swift */,
+				024D59DC28164188007E2727 /* String+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -610,6 +613,7 @@
 				02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */,
 				024D59D22811216B007E2727 /* Font.swift in Sources */,
 				0082808028163A1700825F54 /* DishCellViewModel.swift in Sources */,
+				024D59DD28164188007E2727 /* String+.swift in Sources */,
 				024D59D728123C25007E2727 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SideDish/SideDish/Extensions/String+.swift
+++ b/SideDish/SideDish/Extensions/String+.swift
@@ -10,7 +10,7 @@ extension String {
     }
 
     func toPrice() -> String {
-        var price = self
+        var price = String(self.reversed())
         var splittedPrice = [String]()
         let offset = 3
 
@@ -18,14 +18,14 @@ extension String {
             let startPoint = price.startIndex
             let endPoint = price.index(startPoint, offsetBy: offset)
 
-            splittedPrice.append(String(price[startPoint..<endPoint]))
+            splittedPrice.append(String(price[startPoint..<endPoint].reversed()))
             price.removeSubrange(startPoint..<endPoint)
 
             if price.count <= offset {
-                splittedPrice.append(price)
+                splittedPrice.append(String(price.reversed()))
             }
         }
 
-        return splittedPrice.joined(separator: ",")
+        return splittedPrice.reversed().joined(separator: ",") + "원"
     }
 }

--- a/SideDish/SideDish/Extensions/String+.swift
+++ b/SideDish/SideDish/Extensions/String+.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension String {
+    func toInt() -> Int {
+        let price = self
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: "원", with: "")
+
+        return Int(price) ?? 0
+    }
+
+    func toPrice() -> String {
+        var price = self
+        var splittedPrice = [String]()
+        let offset = 3
+
+        while price.count > offset {
+            let startPoint = price.startIndex
+            let endPoint = price.index(startPoint, offsetBy: offset)
+
+            splittedPrice.append(String(price[startPoint..<endPoint]))
+            price.removeSubrange(startPoint..<endPoint)
+
+            if price.count <= offset {
+                splittedPrice.append(price)
+            }
+        }
+
+        return splittedPrice.joined(separator: ",")
+    }
+}

--- a/SideDish/SideDish/View/DetailView.swift
+++ b/SideDish/SideDish/View/DetailView.swift
@@ -100,6 +100,7 @@ class DetailView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.preferredMaxLayoutWidth = 57
         label.textAlignment = .center
+        label.text = "0"
         return label
     }()
 
@@ -116,6 +117,7 @@ class DetailView: UIView {
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
+        label.text = "원"
         return label
     }()
 

--- a/SideDish/SideDish/View/DetailView.swift
+++ b/SideDish/SideDish/View/DetailView.swift
@@ -74,7 +74,6 @@ class DetailView: UIView {
         label.font = UIFont.init(name: Font.sfRegular, size: 14)
         label.textColor = .grey1
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "126원"
         return label
     }()
 
@@ -381,6 +380,17 @@ class DetailView: UIView {
         amountComponetnsStackView.alignment = .fill
         amountComponetnsStackView.spacing = 0
         amountComponetnsStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        let action = UIAction {_ in
+            let amount = Int(self.amountStepper.value)
+            self.amountLabel.text = String(amount)
+
+            let finalPrice = self.finalPriceLabel.text?.toInt() ?? 0
+
+            let totalPrice = finalPrice * amount
+            self.totalPriceLabel.text = String(totalPrice).toPrice()
+        }
+        amountStepper.addAction(action, for: .touchUpInside)
 
         amountComponetnsStackView.addArrangedSubview(amountLabel)
         amountComponetnsStackView.addArrangedSubview(amountStepper)


### PR DESCRIPTION
## 데모
![SS 2022-04-25 PM 01 59 38](https://user-images.githubusercontent.com/92504186/165024370-078051ad-63fa-4072-9683-3c8eb7d212f0.gif)

## 관련 이슈
issue progress in review #19 

## 작업 내역
- [x] amountLabel(주문 수량을 나타내는 Label)과 amountStepper, totalPriceLabel, normalPriceLabel을 연결시키기
  - [x] normalPriceLabel의 text를 parsing하는 로직 구현
  - [x] (normalPriceLabel.text) * (amountLabel.text) 의 결과값에 천단위마다 `,`를 붙이고 마지막에 `원` 을 붙여 원하는 모습으로 totalPriceLabel.text에 들어갈 수 있도록 구현

## 디테일
- String을 확장해서 `"12,640원"` String값을 `"12640"` 이라는 Int값으로 변환해주는 메소드와, `"12640"`이라는 String 값을 `"12,640원"` 형태의 String 값으로 변환시켜주는 메소드를 구현했습니다.
   ```swift
   extension String {
       func toInt() -> Int {
           let price = self
               .replacingOccurrences(of: ",", with: "")
               .replacingOccurrences(of: "원", with: "")

           return Int(price) ?? 0
       }

       func toPrice() -> String {
           var price = String(self.reversed())
           var splittedPrice = [String]()
           let offset = 3

           while price.count > offset {
               let startPoint = price.startIndex
               let endPoint = price.index(startPoint, offsetBy: offset)

               splittedPrice.append(String(price[startPoint..<endPoint].reversed()))
               price.removeSubrange(startPoint..<endPoint)

               if price.count <= offset {
                   splittedPrice.append(String(price.reversed()))
               }
           }

           return splittedPrice.reversed().joined(separator: ",") + "원"
       }
   }
   ```