### PR TITLE
[모델링] DishDetail과 관련된 ViewModel, Repository, Entity 구현

### DIFF
--- a/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		024D59D92812430F007E2727 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D82812430F007E2727 /* DetailView.swift */; };
 		024D59DF281688E1007E2727 /* DishDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59DE281688E1007E2727 /* DishDetail.swift */; };
 		024D59E1281689A9007E2727 /* DetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E0281689A9007E2727 /* DetailData.swift */; };
+		024D59E928169265007E2727 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E828169265007E2727 /* NetworkError.swift */; };
 		0279B33F280FDB9E00DDBA6E /* DishCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0279B33D280FDB9E00DDBA6E /* DishCell.swift */; };
 		0279B340280FDB9E00DDBA6E /* DishCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0279B33E280FDB9E00DDBA6E /* DishCell.xib */; };
 		02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F119C928102B0E00B9B6A7 /* DetailViewController.swift */; };
@@ -82,6 +83,7 @@
 		024D59D82812430F007E2727 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		024D59DE281688E1007E2727 /* DishDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishDetail.swift; sourceTree = "<group>"; };
 		024D59E0281689A9007E2727 /* DetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailData.swift; sourceTree = "<group>"; };
+		024D59E828169265007E2727 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		0279B33D280FDB9E00DDBA6E /* DishCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DishCell.swift; sourceTree = "<group>"; };
 		0279B33E280FDB9E00DDBA6E /* DishCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DishCell.xib; sourceTree = "<group>"; };
 		02F119C928102B0E00B9B6A7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 			isa = PBXGroup;
 			children = (
 				024D59D12811216B007E2727 /* Font.swift */,
+				024D59E828169265007E2727 /* NetworkError.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -604,6 +607,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				024D59E928169265007E2727 /* NetworkError.swift in Sources */,
 				2A50C19A280D55F400AFF2F7 /* AppDelegate.swift in Sources */,
 				2A50C1A4280D55F400AFF2F7 /* SideDish.xcdatamodeld in Sources */,
 				024D59E1281689A9007E2727 /* DetailData.swift in Sources */,

--- a/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		024D59E1281689A9007E2727 /* DetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E0281689A9007E2727 /* DetailData.swift */; };
 		024D59E328168A29007E2727 /* DishDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E228168A29007E2727 /* DishDetailRepository.swift */; };
 		024D59E928169265007E2727 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E828169265007E2727 /* NetworkError.swift */; };
+		024D59EB28169379007E2727 /* DishDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59EA28169379007E2727 /* DishDetailViewModel.swift */; };
 		024D59ED2816BAFC007E2727 /* DiscountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59EC2816BAFC007E2727 /* DiscountType.swift */; };
 		0279B33F280FDB9E00DDBA6E /* DishCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0279B33D280FDB9E00DDBA6E /* DishCell.swift */; };
 		0279B340280FDB9E00DDBA6E /* DishCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0279B33E280FDB9E00DDBA6E /* DishCell.xib */; };
@@ -87,6 +88,7 @@
 		024D59E0281689A9007E2727 /* DetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailData.swift; sourceTree = "<group>"; };
 		024D59E228168A29007E2727 /* DishDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishDetailRepository.swift; sourceTree = "<group>"; };
 		024D59E828169265007E2727 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		024D59EA28169379007E2727 /* DishDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishDetailViewModel.swift; sourceTree = "<group>"; };
 		024D59EC2816BAFC007E2727 /* DiscountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountType.swift; sourceTree = "<group>"; };
 		0279B33D280FDB9E00DDBA6E /* DishCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DishCell.swift; sourceTree = "<group>"; };
 		0279B33E280FDB9E00DDBA6E /* DishCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DishCell.xib; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				0082807F28163A1700825F54 /* DishCellViewModel.swift */,
+				024D59EA28169379007E2727 /* DishDetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 				02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */,
 				024D59ED2816BAFC007E2727 /* DiscountType.swift in Sources */,
 				024D59D22811216B007E2727 /* Font.swift in Sources */,
+				024D59EB28169379007E2727 /* DishDetailViewModel.swift in Sources */,
 				0082808028163A1700825F54 /* DishCellViewModel.swift in Sources */,
 				024D59D728123C25007E2727 /* UIColor+.swift in Sources */,
 			);

--- a/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		024D59D92812430F007E2727 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D82812430F007E2727 /* DetailView.swift */; };
 		024D59DF281688E1007E2727 /* DishDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59DE281688E1007E2727 /* DishDetail.swift */; };
 		024D59E1281689A9007E2727 /* DetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E0281689A9007E2727 /* DetailData.swift */; };
+		024D59E328168A29007E2727 /* DishDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E228168A29007E2727 /* DishDetailRepository.swift */; };
 		024D59E928169265007E2727 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E828169265007E2727 /* NetworkError.swift */; };
 		0279B33F280FDB9E00DDBA6E /* DishCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0279B33D280FDB9E00DDBA6E /* DishCell.swift */; };
 		0279B340280FDB9E00DDBA6E /* DishCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0279B33E280FDB9E00DDBA6E /* DishCell.xib */; };
@@ -83,6 +84,7 @@
 		024D59D82812430F007E2727 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		024D59DE281688E1007E2727 /* DishDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishDetail.swift; sourceTree = "<group>"; };
 		024D59E0281689A9007E2727 /* DetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailData.swift; sourceTree = "<group>"; };
+		024D59E228168A29007E2727 /* DishDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishDetailRepository.swift; sourceTree = "<group>"; };
 		024D59E828169265007E2727 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		0279B33D280FDB9E00DDBA6E /* DishCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DishCell.swift; sourceTree = "<group>"; };
 		0279B33E280FDB9E00DDBA6E /* DishCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DishCell.xib; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				0082807D281639B400825F54 /* Entity */,
+				024D59E228168A29007E2727 /* DishDetailRepository.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -608,6 +611,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				024D59E928169265007E2727 /* NetworkError.swift in Sources */,
+				024D59E328168A29007E2727 /* DishDetailRepository.swift in Sources */,
 				2A50C19A280D55F400AFF2F7 /* AppDelegate.swift in Sources */,
 				2A50C1A4280D55F400AFF2F7 /* SideDish.xcdatamodeld in Sources */,
 				024D59E1281689A9007E2727 /* DetailData.swift in Sources */,

--- a/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		024D59E1281689A9007E2727 /* DetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E0281689A9007E2727 /* DetailData.swift */; };
 		024D59E328168A29007E2727 /* DishDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E228168A29007E2727 /* DishDetailRepository.swift */; };
 		024D59E928169265007E2727 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E828169265007E2727 /* NetworkError.swift */; };
+		024D59ED2816BAFC007E2727 /* DiscountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59EC2816BAFC007E2727 /* DiscountType.swift */; };
 		0279B33F280FDB9E00DDBA6E /* DishCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0279B33D280FDB9E00DDBA6E /* DishCell.swift */; };
 		0279B340280FDB9E00DDBA6E /* DishCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0279B33E280FDB9E00DDBA6E /* DishCell.xib */; };
 		02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F119C928102B0E00B9B6A7 /* DetailViewController.swift */; };
@@ -86,6 +87,7 @@
 		024D59E0281689A9007E2727 /* DetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailData.swift; sourceTree = "<group>"; };
 		024D59E228168A29007E2727 /* DishDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishDetailRepository.swift; sourceTree = "<group>"; };
 		024D59E828169265007E2727 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		024D59EC2816BAFC007E2727 /* DiscountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountType.swift; sourceTree = "<group>"; };
 		0279B33D280FDB9E00DDBA6E /* DishCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DishCell.swift; sourceTree = "<group>"; };
 		0279B33E280FDB9E00DDBA6E /* DishCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DishCell.xib; sourceTree = "<group>"; };
 		02F119C928102B0E00B9B6A7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 			isa = PBXGroup;
 			children = (
 				0082807D281639B400825F54 /* Entity */,
+				024D59EC2816BAFC007E2727 /* DiscountType.swift */,
 				024D59E228168A29007E2727 /* DishDetailRepository.swift */,
 			);
 			path = Model;
@@ -624,6 +627,7 @@
 				024D59DF281688E1007E2727 /* DishDetail.swift in Sources */,
 				024D59D428112409007E2727 /* PaddingLabel.swift in Sources */,
 				02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */,
+				024D59ED2816BAFC007E2727 /* DiscountType.swift in Sources */,
 				024D59D22811216B007E2727 /* Font.swift in Sources */,
 				0082808028163A1700825F54 /* DishCellViewModel.swift in Sources */,
 				024D59D728123C25007E2727 /* UIColor+.swift in Sources */,

--- a/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		024D59D428112409007E2727 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D328112409007E2727 /* PaddingLabel.swift */; };
 		024D59D728123C25007E2727 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D628123C25007E2727 /* UIColor+.swift */; };
 		024D59D92812430F007E2727 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59D82812430F007E2727 /* DetailView.swift */; };
+		024D59DF281688E1007E2727 /* DishDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59DE281688E1007E2727 /* DishDetail.swift */; };
+		024D59E1281689A9007E2727 /* DetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024D59E0281689A9007E2727 /* DetailData.swift */; };
 		0279B33F280FDB9E00DDBA6E /* DishCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0279B33D280FDB9E00DDBA6E /* DishCell.swift */; };
 		0279B340280FDB9E00DDBA6E /* DishCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0279B33E280FDB9E00DDBA6E /* DishCell.xib */; };
 		02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F119C928102B0E00B9B6A7 /* DetailViewController.swift */; };
@@ -78,6 +80,8 @@
 		024D59D328112409007E2727 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		024D59D628123C25007E2727 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		024D59D82812430F007E2727 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		024D59DE281688E1007E2727 /* DishDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishDetail.swift; sourceTree = "<group>"; };
+		024D59E0281689A9007E2727 /* DetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailData.swift; sourceTree = "<group>"; };
 		0279B33D280FDB9E00DDBA6E /* DishCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DishCell.swift; sourceTree = "<group>"; };
 		0279B33E280FDB9E00DDBA6E /* DishCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DishCell.xib; sourceTree = "<group>"; };
 		02F119C928102B0E00B9B6A7 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
@@ -155,6 +159,8 @@
 			isa = PBXGroup;
 			children = (
 				0082808128163A3D00825F54 /* DishCellInfo.swift */,
+				024D59DE281688E1007E2727 /* DishDetail.swift */,
+				024D59E0281689A9007E2727 /* DetailData.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -600,12 +606,14 @@
 			files = (
 				2A50C19A280D55F400AFF2F7 /* AppDelegate.swift in Sources */,
 				2A50C1A4280D55F400AFF2F7 /* SideDish.xcdatamodeld in Sources */,
+				024D59E1281689A9007E2727 /* DetailData.swift in Sources */,
 				0082808228163A3D00825F54 /* DishCellInfo.swift in Sources */,
 				0049FA54280EF2EB00470FCD /* SectionHeader.swift in Sources */,
 				0279B33F280FDB9E00DDBA6E /* DishCell.swift in Sources */,
 				2A50C19C280D55F400AFF2F7 /* SceneDelegate.swift in Sources */,
 				024D59D92812430F007E2727 /* DetailView.swift in Sources */,
 				0049FA52280EE98300470FCD /* HomeViewController.swift in Sources */,
+				024D59DF281688E1007E2727 /* DishDetail.swift in Sources */,
 				024D59D428112409007E2727 /* PaddingLabel.swift in Sources */,
 				02F119CA28102B0E00B9B6A7 /* DetailViewController.swift in Sources */,
 				024D59D22811216B007E2727 /* Font.swift in Sources */,

--- a/SideDish/SideDish/Model/DiscountType.swift
+++ b/SideDish/SideDish/Model/DiscountType.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum DiscountType {
+    case event
+    case launching
+
+    var description: String {
+        switch self {
+        case .event:
+            return "이벤트특가"
+        case .launching:
+            return "런칭특가"
+        }
+    }
+
+    init?(_ rawValue: String) {
+        switch rawValue {
+        case "이벤트특가":
+            self = .event
+        case "런칭특가":
+            self = .launching
+        default:
+            return nil
+        }
+    }
+}

--- a/SideDish/SideDish/Model/DishDetailRepository.swift
+++ b/SideDish/SideDish/Model/DishDetailRepository.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class DishDetailRepository {
+
+    func fetchDishDetail(of hashDetail: String, _ completion: @escaping (Result<DishDetail, NetworkError>) -> Void) {
+        guard let url = URL(string: "https://api.codesquad.kr/onban/detail/" + "\(hashDetail)") else { return completion(.failure(.wrongEndPoint))}
+
+        URLSession.shared.dataTask(with: url) { (data, response, error) in
+            if error != nil {
+                return completion(.failure(.transferError))
+            }
+
+            guard let data = data else {
+                return completion(.failure(.noData))
+            }
+
+            guard let response = response as? HTTPURLResponse else { return }
+            let statusCode = response.statusCode
+
+            guard 200..<300 ~= statusCode else {
+                return completion(.failure(.serverError(statusCode: statusCode)))
+            }
+
+            let decoder = JSONDecoder()
+
+            if let decodedData = try? decoder.decode(DishDetail.self, from: data) {
+                completion(.success(decodedData))
+            } else {
+                completion(.failure(.unDecoded))
+            }
+        }.resume()
+    }
+}

--- a/SideDish/SideDish/Model/DishDetailRepository.swift
+++ b/SideDish/SideDish/Model/DishDetailRepository.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class DishDetailRepository {
 
-    func fetchDishDetail(of hashDetail: String, _ completion: @escaping (Result<DishDetail, NetworkError>) -> Void) {
+    func fetchDishDetail(of hashDetail: String, _ completion: @escaping (Result<DetailData, NetworkError>) -> Void) {
         guard let url = URL(string: "https://api.codesquad.kr/onban/detail/" + "\(hashDetail)") else { return completion(.failure(.wrongEndPoint))}
 
         URLSession.shared.dataTask(with: url) { (data, response, error) in
@@ -24,7 +24,7 @@ class DishDetailRepository {
             let decoder = JSONDecoder()
 
             if let decodedData = try? decoder.decode(DishDetail.self, from: data) {
-                completion(.success(decodedData))
+                completion(.success(decodedData.data))
             } else {
                 completion(.failure(.unDecoded))
             }

--- a/SideDish/SideDish/Model/Entity/DetailData.swift
+++ b/SideDish/SideDish/Model/Entity/DetailData.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct DetailData: Codable {
+    let topImage: String
+    let thumbImages: [String]
+    let productDescription, point, deliveryInfo, deliveryFee: String
+    let prices: [String]
+    let detailSection: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case topImage = "top_image"
+        case thumbImages = "thumb_images"
+        case productDescription = "product_description"
+        case point
+        case deliveryInfo = "delivery_info"
+        case deliveryFee = "delivery_fee"
+        case prices
+        case detailSection = "detail_section"
+    }
+}

--- a/SideDish/SideDish/Model/Entity/DishDetail.swift
+++ b/SideDish/SideDish/Model/Entity/DishDetail.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct DishDetail: Codable {
+    let hash: String
+    let data: DetailData
+}

--- a/SideDish/SideDish/Support/NetworkError.swift
+++ b/SideDish/SideDish/Support/NetworkError.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum NetworkError: Error {
+    case noData
+    case transferError
+    case wrongEndPoint
+    case serverError(statusCode: Int)
+    case unDecoded
+}

--- a/SideDish/SideDish/View/DetailView.swift
+++ b/SideDish/SideDish/View/DetailView.swift
@@ -137,7 +137,7 @@ class DetailView: UIView {
         return button
     }()
 
-    private let detailImageStackView: UIStackView = {
+    let detailImageStackView: UIStackView = {
         var stackView = UIStackView()
         stackView.axis = .vertical
         stackView.distribution = .fill

--- a/SideDish/SideDish/View/DetailViewController.swift
+++ b/SideDish/SideDish/View/DetailViewController.swift
@@ -28,11 +28,9 @@ class DetailViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        navigationController?.navigationBar.topItem?.title = "뒤로"
+        navigationController?.navigationBar.topItem?.backButtonTitle = "뒤로"
         navigationController?.navigationBar.titleTextAttributes =
         [NSAttributedString.Key.font: UIFont(name: Font.sfSemiBold, size: 17) ?? UIFont.systemFont(ofSize: 17)]
-        navigationItem.title = "오리 주물럭_반조리"
 
         detailView.setLayout()
     }
@@ -40,6 +38,7 @@ class DetailViewController: UIViewController {
     private func setViewModel() {
         viewModel?.onUpdate = {
             DispatchQueue.main.async {
+                self.navigationItem.title = self.viewModel?.title
                 self.detailView.titleLabel.text = self.viewModel?.title
                 self.detailView.descriptionLabel.text = self.viewModel?.description
                 self.detailView.finalPriceLabel.text = self.viewModel?.finalPrice

--- a/SideDish/SideDish/View/DetailViewController.swift
+++ b/SideDish/SideDish/View/DetailViewController.swift
@@ -2,7 +2,29 @@ import UIKit
 
 class DetailViewController: UIViewController {
 
-    private let detailView = DetailView()
+    private let detailView: DetailView
+    private var viewModel: DishDetailViewModel?
+
+    init(viewModel: DishDetailViewModel) {
+        detailView = DetailView()
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+
+        setViewModel()
+    }
+
+    required init?(coder: NSCoder) {
+        detailView = DetailView()
+        self.viewModel = nil
+        super.init(coder: coder)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewModel?.fetchDetailData()
+        view = detailView
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -13,6 +35,57 @@ class DetailViewController: UIViewController {
         navigationItem.title = "오리 주물럭_반조리"
 
         detailView.setLayout()
-        view = detailView
+    }
+
+    private func setViewModel() {
+        viewModel?.onUpdate = {
+            DispatchQueue.main.async {
+                self.detailView.titleLabel.text = self.viewModel?.title
+                self.detailView.descriptionLabel.text = self.viewModel?.description
+                self.detailView.finalPriceLabel.text = self.viewModel?.finalPrice
+                self.detailView.normalPriceLabel.text = self.viewModel?.normalPrice
+                self.detailView.pointLabel.text = self.viewModel?.point
+                self.detailView.shippingInfoLabel.text = self.viewModel?.deliveryInfo
+                self.detailView.shippingFeeLabel.text = self.viewModel?.deliveryFee
+
+                if let normalPrice = self.viewModel?.normalPrice {
+                    let attributedStyle = NSUnderlineStyle.single
+                    let attributedString = NSMutableAttributedString(string: normalPrice)
+                    attributedString.addAttribute(NSAttributedString.Key.strikethroughStyle,
+                                                  value: attributedStyle.rawValue,
+                                                  range: NSRange(0..<attributedString.length))
+                    self.detailView.normalPriceLabel.attributedText = attributedString
+                }
+            }
+        }
+
+        viewModel?.onUpdateWithTopImages = {
+            DispatchQueue.main.async {
+                self.viewModel?.topImages.forEach { image in
+                    let topImageView = UIImageView(image: image)
+                    topImageView.contentMode = .scaleAspectFit
+                    topImageView.widthAnchor.constraint(equalTo: topImageView.heightAnchor).isActive = true
+
+                    self.detailView.productImageContentView.addArrangedSubview(topImageView)
+                }
+            }
+        }
+
+        viewModel?.onUpdateWithDetailImages = {
+            DispatchQueue.main.async {
+                self.viewModel?.detailImages.forEach { image in
+                    let ratio = image.size.height / image.size.width
+                    let detailImageView = UIImageView(image: image)
+                    let newWidth = self.detailView.detailImageStackView.frame.width
+                    let newHeight = newWidth * ratio
+
+                    detailImageView.contentMode = .scaleAspectFit
+                    detailImageView.translatesAutoresizingMaskIntoConstraints = false
+                    detailImageView.heightAnchor.constraint(equalToConstant: newHeight).isActive = true
+
+                    self.detailView.detailImageStackView.addArrangedSubview(detailImageView)
+                }
+            }
+        }
     }
 }

--- a/SideDish/SideDish/View/DishCell.swift
+++ b/SideDish/SideDish/View/DishCell.swift
@@ -10,12 +10,14 @@ class DishCell: UICollectionViewCell {
     @IBOutlet weak var finalPriceLabel: UILabel!
     @IBOutlet weak var normalPriceLabel: UILabel!
     @IBOutlet weak var badgeView: UIView!
+    @IBOutlet weak var eventBadgeLabel: UILabel!
+    @IBOutlet weak var launchingBadgeLabel: UILabel!
 
     override func awakeFromNib() {
         super.awakeFromNib()
     }
 
-    func configure(image: UIImage, title: String, description: String, finalPrice: Int, normalPrice: Int?, discountType: DiscountType?) {
+    func configure(image: UIImage, title: String, description: String, finalPrice: Int, normalPrice: Int?, discountType: [DiscountType]?) {
         thumbNailImageView.image = image
         titleLabel.text = title
         descriptionLabel.text = description
@@ -32,34 +34,20 @@ class DishCell: UICollectionViewCell {
             normalPriceLabel.attributedText = attributedString
         }
 
-        if let discountType = discountType,
-           let badgeLabel = badgeView.subviews.first as? UILabel {
+        if let discountType = discountType {
             badgeView.isHidden = false
-            badgeLabel.backgroundColor = discountType.labelColor
-            badgeLabel.text = discountType.description
-        }
-    }
-}
+            discountType.forEach {
+                switch $0 {
+                case .event:
+                    self.eventBadgeLabel.isHidden = false
+                case .launching:
+                    self.launchingBadgeLabel.isHidden = false
+                }
+            }
 
-enum DiscountType {
-    case event
-    case launching
-
-    var description: String {
-        switch self {
-        case .event:
-                return "이벤트특가"
-        case .launching:
-                return "런칭특가"
-        }
-    }
-
-    var labelColor: UIColor {
-        switch self {
-        case .event:
-                return UIColor.init(red: 0, green: 102/255, blue: 214/255, alpha: 1.0)
-        case .launching:
-                return UIColor.init(red: 128/255, green: 188/255, blue: 1, alpha: 1.0)
+            if self.eventBadgeLabel.isHidden == true && self.launchingBadgeLabel.isHidden == false {
+                self.launchingBadgeLabel.leadingAnchor.constraint(equalTo: self.badgeView.leadingAnchor).isActive = true
+            }
         }
     }
 }

--- a/SideDish/SideDish/View/DishCell.xib
+++ b/SideDish/SideDish/View/DishCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -78,28 +78,68 @@
                                     <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="205" placeholderIntrinsicHeight="32" translatesAutoresizingMaskIntoConstraints="NO" id="dYU-xp-9B4">
                                         <rect key="frame" x="0.0" y="72" width="205" height="32"/>
                                         <subviews>
-                                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L2i-Mj-oUm" userLabel="BadgeLabel">
-                                                <rect key="frame" x="0.0" y="8" width="32" height="24"/>
+                                            <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이벤트특가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6i-OV-plJ" userLabel="EventLabel" customClass="PaddingLabel" customModule="SideDish" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="8" width="52" height="14.5"/>
+                                                <color key="backgroundColor" red="0.55294120309999995" green="0.72941178080000002" blue="0.97647058959999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="iwD-Ly-dTM"/>
-                                                    <constraint firstAttribute="height" constant="24" id="mlB-m4-I29"/>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="Sv1-qc-78M"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" name="SFProDisplay-Regular" family="SF Pro Display" pointSize="12"/>
+                                                <fontDescription key="fontDescription" name="SFProDisplay-Semibold" family="SF Pro Display" pointSize="12"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                                 <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="topInset">
+                                                        <real key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="bottomInset">
+                                                        <real key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="leftInset">
+                                                        <real key="value" value="16"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="rightInset">
+                                                        <real key="value" value="16"/>
+                                                    </userDefinedRuntimeAttribute>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                        <integer key="value" value="100"/>
+                                                        <integer key="value" value="12"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </label>
+                                            <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="런칭특가" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2tE-YU-uR3" userLabel="LaunchingLabel" customClass="PaddingLabel" customModule="SideDish" customModuleProvider="target">
+                                                <rect key="frame" x="56" y="8" width="42" height="14.5"/>
+                                                <color key="backgroundColor" red="0.1647058874" green="0.39215683940000001" blue="0.81176471709999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="h0x-uX-ir9"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" name="SFProDisplay-Semibold" family="SF Pro Display" pointSize="12"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="topInset">
+                                                        <real key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="bottomInset">
+                                                        <real key="value" value="4"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="leftInset">
+                                                        <real key="value" value="16"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="rightInset">
+                                                        <real key="value" value="16"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="12"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
                                             </label>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstItem="L2i-Mj-oUm" firstAttribute="top" secondItem="dYU-xp-9B4" secondAttribute="top" constant="8" id="5tr-OV-eho"/>
-                                            <constraint firstAttribute="bottom" secondItem="L2i-Mj-oUm" secondAttribute="bottom" id="MYJ-hY-f5y"/>
-                                            <constraint firstItem="L2i-Mj-oUm" firstAttribute="leading" secondItem="dYU-xp-9B4" secondAttribute="leading" id="Oxi-4g-cxN"/>
+                                            <constraint firstItem="2tE-YU-uR3" firstAttribute="leading" secondItem="p6i-OV-plJ" secondAttribute="trailing" constant="4" id="PW4-6q-cDK"/>
+                                            <constraint firstItem="p6i-OV-plJ" firstAttribute="top" secondItem="dYU-xp-9B4" secondAttribute="top" constant="8" id="Sqq-Q9-Lig"/>
+                                            <constraint firstItem="p6i-OV-plJ" firstAttribute="leading" secondItem="dYU-xp-9B4" secondAttribute="leading" id="TcJ-eT-w49"/>
                                             <constraint firstAttribute="height" constant="32" id="kLA-nl-yA2"/>
+                                            <constraint firstItem="2tE-YU-uR3" firstAttribute="top" secondItem="dYU-xp-9B4" secondAttribute="top" constant="8" id="rbi-r0-zCN"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -131,7 +171,9 @@
             <connections>
                 <outlet property="badgeView" destination="dYU-xp-9B4" id="wIH-kj-RWT"/>
                 <outlet property="descriptionLabel" destination="mvw-cG-Dft" id="pTU-ep-qaR"/>
+                <outlet property="eventBadgeLabel" destination="p6i-OV-plJ" id="EZD-cU-cBX"/>
                 <outlet property="finalPriceLabel" destination="dO6-Pv-XTR" id="uE9-js-TPe"/>
+                <outlet property="launchingBadgeLabel" destination="2tE-YU-uR3" id="Y3d-Mb-inH"/>
                 <outlet property="normalPriceLabel" destination="Vq3-Th-6fp" id="wUc-L0-NFS"/>
                 <outlet property="thumbNailImageView" destination="kdg-E1-T7e" id="Sww-Uv-0wt"/>
                 <outlet property="titleLabel" destination="Jqf-Ku-PoY" id="c56-aa-H3I"/>

--- a/SideDish/SideDish/ViewModel/DishDetailViewModel.swift
+++ b/SideDish/SideDish/ViewModel/DishDetailViewModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+import UIKit
+import OSLog
+
+final class DishDetailViewModel {
+    private let repository: DishDetailRepository
+    private let detailHash: String
+
+    private(set) var topImages = [UIImage]()
+    private(set) var title = ""
+    private(set) var description = ""
+    private(set) var finalPrice = ""
+    private(set) var normalPrice: String?
+    private(set) var discountType: [DiscountType] = []
+    private(set) var point = ""
+    private(set) var deliveryInfo = ""
+    private(set) var deliveryFee = ""
+    private(set) var detailImages = [UIImage]()
+
+    var onUpdate: () -> Void = {}
+    var onUpdateWithTopImages: () -> Void = {}
+    var onUpdateWithDetailImages: () -> Void = {}
+
+    init(detailHash: String, repository: DishDetailRepository) {
+        self.detailHash = detailHash
+        self.repository = repository
+    }
+
+    func fetchDetailData() {
+        self.repository.fetchDishDetail(of: detailHash) {result in
+            switch result {
+            case .failure(let error):
+                os_log(.error, "\(error.localizedDescription)")
+
+            case .success(let dishDetail):
+                DispatchQueue.global().async {
+                    dishDetail.thumbImages.forEach { imageURL in
+                        guard let url = URL(string: imageURL) else {return}
+                        if let data = try? Data(contentsOf: url),
+                           let downloadedImage = UIImage(data: data) {
+                            DispatchQueue.main.async {
+                                self.topImages.append(downloadedImage)
+                            }
+                        }
+                    }
+                    self.onUpdateWithTopImages()
+
+                    dishDetail.detailSection.forEach { imageURL in
+                        guard let url = URL(string: imageURL) else {return}
+                        if let data = try? Data(contentsOf: url),
+                           let downloadedImage = UIImage(data: data) {
+                            DispatchQueue.main.async {
+                                self.detailImages.append(downloadedImage)
+                            }
+                        }
+                    }
+                    self.onUpdateWithDetailImages()
+                }
+                self.description = dishDetail.productDescription
+                self.finalPrice = dishDetail.prices[0]
+                if dishDetail.prices.count > 1 {
+                    self.normalPrice = dishDetail.prices[1]
+                }
+
+                self.point = dishDetail.point
+                self.deliveryInfo = dishDetail.deliveryInfo
+                self.deliveryFee = dishDetail.deliveryFee
+                self.onUpdate()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 데모
![SS 2022-04-26 PM 05 23 54](https://user-images.githubusercontent.com/92504186/165256108-e9e1e50c-f3c6-4d19-98ef-f0a8723a57a9.gif)

## 관련 이슈
issue progress in review #21 

## 작업 내역
- [x] DishDetail과 관련된 Entity 구현 (DishDetail, DetailData)
- [x] NetworkError 열거형 구현
- [x] DishDetail과 관련된 Repository 구현 (DishDetailRepository)
- [x] DishCell의 badgeView가 보여지는 방식 수정 
- [x] DishDetail과 관련된 ViewModel 구현 (DishDetailViewModel)
- [x] DetailViewController 수정 및 "뒤로"버튼으로 인한 이슈 해결

## 디테일
1. DishCell의 badgeView에 있는 badgeLabel이 하나만 있을 거라고 예상하여, 해당 부분을 하나의 Label을 변형시켜주는 식으로 구현했었는데, 서버에서 온 데이터를 살펴보니 badgeLabel이 2개인 경우도 있다는걸 알게되어 해당 부분을 수정했습니다.
  필요한 badgeLabel의 종류(DiscountType)에 따라 미리 그려져있는 badgeLabel의 isHidden 프로퍼티를 수정해주는 방법으로 고쳤습니다.
2. DetailViewController의 "뒤로" 버튼의 이름을 설정하기 위해 기존에는 `navigationController?.navigationBar.topItem?.title = "뒤로"`의 방법으로 설정해주었으나, 이 방법을 사용하면 해당 버튼을 눌렀을 때 나타나는 VC의 title 또한 "뒤로"가 되는 문제가 있었습니다. 
  이 문제를 해결하기 위해 `navigationController?.navigationBar.topItem?.backButtonTitle = "뒤로"`의 방법으로 버튼의 이름을 설정해주었더니 문제가 해결되었습니다. 