### PR TITLE
[모델링] Home View Controller수정 요청 사항 반영

### DIFF
--- a/SideDish/.SwiftLint.yml
+++ b/SideDish/.SwiftLint.yml
@@ -1,2 +1,3 @@
 excluded: # 린트 과정에서 무시할 파일 경로. `included`보다 우선순위 높음
   - Pods
+  - SideDish/View/DetailView.swift

--- a/SideDish/SideDish/Base/Base.lproj/Main.storyboard
+++ b/SideDish/SideDish/Base/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wc6-7z-dnc">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wc6-7z-dnc">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -14,11 +14,11 @@
             <objects>
                 <viewController id="fhN-Dl-XbC" customClass="HomeViewController" customModule="SideDish" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="obF-qq-rBh">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="5Yi-mI-Dmc">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="756"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="n4W-wP-L1b">
                                     <size key="itemSize" width="128" height="128"/>
@@ -38,11 +38,11 @@
                                     </collectionViewCell>
                                 </cells>
                                 <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="homeHeaderView" id="7gc-Mk-D5e" customClass="SectionHeader" customModule="SideDish" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="390" height="50"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WnB-97-bEV">
-                                            <rect key="frame" x="24" y="15" width="366" height="20.5"/>
+                                            <rect key="frame" x="24" y="14.999999999999998" width="342" height="20.333333333333329"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -84,7 +84,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wc6-7z-dnc" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="SAE-JZ-rSA">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
                             <fontDescription key="fontDescription" name="SFProDisplay-Semibold" family="SF Pro Display" pointSize="17"/>

--- a/SideDish/SideDish/Base/Info.plist
+++ b/SideDish/SideDish/Base/Info.plist
@@ -4,14 +4,8 @@
 <dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>public.codesquad.co.kr</key>
-			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>Damagucci.SideDish</string>

--- a/SideDish/SideDish/Base/Info.plist
+++ b/SideDish/SideDish/Base/Info.plist
@@ -4,9 +4,17 @@
 <dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>public.codesquad.co.kr</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>Damagucci.SideDish</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>SF-Pro-Display-Semibold.otf</string>

--- a/SideDish/SideDish/Support/CellFactory.swift
+++ b/SideDish/SideDish/Support/CellFactory.swift
@@ -8,7 +8,14 @@ protocol CellFactoryProtocol {
 
 final class CellFactory: CellFactoryProtocol {
     private let repository: DishCellRepositoryProtocol
-    private(set) var products: [ProductSort: [DishCellInfo]] = [:]
+    private(set) var products: [ProductSort: [DishCellInfo]] = [:] {
+        didSet {
+            let requiredSectionCount = 3
+            if products.count == requiredSectionCount {
+                self.onUpdate()
+            }
+        }
+    }
     var onUpdate: () -> Void = { }
 
     init(repository: DishCellRepositoryProtocol) {
@@ -22,18 +29,13 @@ final class CellFactory: CellFactoryProtocol {
                 switch result {
                 case .success(let data):
                     self?.products[sort] = data
-                    self?.onUpdate()
                 case .failure:
-                    // TODO: - error handling
                     print("\(sort.rawValue) error happend!!!")
                 }
             }
         }
     }
 
-    func fetchImageFromServer() {
-    }
-    
     func convertCell2Product() -> [ProductSort: [Product]] {
         var resultDictionary: [ProductSort: [Product]] = [ : ]
         for (key, value) in products {

--- a/SideDish/SideDish/Support/CellFactory.swift
+++ b/SideDish/SideDish/Support/CellFactory.swift
@@ -8,7 +8,7 @@ protocol CellFactoryProtocol {
 
 final class CellFactory: CellFactoryProtocol {
     private let repository: DishCellRepositoryProtocol
-    private(set) var products: [[DishCellInfo]] = []
+    private(set) var products: [ProductSort: [DishCellInfo]] = [:]
     var onUpdate: () -> Void = { }
 
     init(repository: DishCellRepositoryProtocol) {
@@ -16,14 +16,12 @@ final class CellFactory: CellFactoryProtocol {
     }
 
     func fetchData() {
-        let allCases = ProductSort.allCases
-        allCases.forEach { sort in
+        let allCases: [ProductSort] = ProductSort.allCases
+        for sort in allCases {
             self.repository.fetchInfo(sort: sort) { [weak self] result in
                 switch result {
                 case .success(let data):
-                    DispatchQueue.main.async {
-                        self?.products.append(data)
-                    }
+                    self?.products[sort] = data
                     self?.onUpdate()
                 case .failure:
                     // TODO: - error handling
@@ -35,14 +33,13 @@ final class CellFactory: CellFactoryProtocol {
 
     func fetchImageFromServer() {
     }
-
-    func convertCell2Product() -> [[Product]] {
-        let productArray: [[Product]] = self.products.map { sectionArray in
-            let array = sectionArray.map { cell in
-                return Product(origin: cell, image: UIImage(systemName: "pencil")!)
-            }
-            return array
+    
+    func convertCell2Product() -> [ProductSort: [Product]] {
+        var resultDictionary: [ProductSort: [Product]] = [ : ]
+        for (key, value) in products {
+            let productArray = value.map { Product(origin: $0, image: UIImage(systemName: "pencil")!)}
+            resultDictionary[key] = productArray
         }
-        return productArray
+        return resultDictionary
     }
 }

--- a/SideDish/SideDish/View/HomeViewController.swift
+++ b/SideDish/SideDish/View/HomeViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 class HomeViewController: UIViewController {
 
     @IBOutlet weak var collectionView: UICollectionView!
-    private var model = [[Product]]()
+    private var model:  [ProductSort: [Product]] = [:]
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,7 +35,16 @@ class HomeViewController: UIViewController {
 
 extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return model[section].count
+        switch section {
+        case 0:
+            return model[.main]?.count ?? 0
+        case 1:
+            return model[.soup]?.count ?? 0
+        case 2:
+            return model[.side]?.count ?? 0
+        default:
+            return 0
+        }
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
@@ -44,8 +53,20 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
                 .dequeueReusableCell(withReuseIdentifier: DishCell.identifier, for: indexPath) as? DishCell else {
                     return UICollectionViewCell()
                 }
-        // TODO: - 팩토리 메서드 패턴으로, 셀.configure
-        cell.configure(with: model[indexPath.section][indexPath.item])
+        guard let main = model[.main] else { return UICollectionViewCell()}
+        guard let soup = model[.soup] else { return UICollectionViewCell()}
+        guard let side = model[.side] else { return UICollectionViewCell()}
+        let sectionNumber = indexPath.section
+        switch sectionNumber {
+        case 0:
+            cell.configure(with: main[indexPath.row])
+        case 1:
+            cell.configure(with: soup[indexPath.row])
+        case 2:
+            cell.configure(with: side[indexPath.row])
+        default:
+            assert(false)
+        }
         return cell
     }
     func numberOfSections(in collectionView: UICollectionView) -> Int {

--- a/SideDish/SideDish/View/HomeViewController.swift
+++ b/SideDish/SideDish/View/HomeViewController.swift
@@ -53,9 +53,12 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
                 .dequeueReusableCell(withReuseIdentifier: DishCell.identifier, for: indexPath) as? DishCell else {
                     return UICollectionViewCell()
                 }
-        guard let main = model[.main] else { return UICollectionViewCell()}
-        guard let soup = model[.soup] else { return UICollectionViewCell()}
-        guard let side = model[.side] else { return UICollectionViewCell()}
+        guard let main = model[.main],
+              let soup = model[.soup],
+              let side = model[.side] else {
+                  return UICollectionViewCell()
+              }
+        
         let sectionNumber = indexPath.section
         switch sectionNumber {
         case 0:
@@ -65,7 +68,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
         case 2:
             cell.configure(with: side[indexPath.row])
         default:
-            assert(false)
+            return UICollectionViewCell()
         }
         return cell
     }
@@ -87,13 +90,22 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
             headerView.setup(at: indexPath.section)
             return headerView
         default:
-            assert(false, "invalid element Type")
+            return UICollectionReusableView()
         }
     }
     // MARK: - Cell 이 클릭되게 만듦
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-
-        let targetDish = model[indexPath.section][indexPath.item]
+        var targetSort: ProductSort = .main
+        switch indexPath.section {
+        case 1:
+            targetSort = .main
+        case 2:
+            targetSort = .soup
+        default:
+            targetSort = .side
+        }
+        guard let targetSection = model[targetSort] else { return }
+        let targetDish = targetSection[indexPath.item]
         let dishTitle = targetDish.title
         let detailHash = targetDish.hash
         let dishDetailViewModel = DishDetailViewModel(title: dishTitle,


### PR DESCRIPTION
# 작업 내역
- [x] 불필요한 3개의 `guard let` 을 1개로 축소
- [x] UI 업데이트 실패시 동작하는 assert(false) 를 UICollectionViewCell() or UICollectionViewReusableView 로 수정(2군데)
- [x] `HomeViewController.model` 의 타입이 변화함에 따라 
        CollectionView 델리게이트에서 indexPath 를 수정해야하는 부분 수정


# 요청 사항 

![image](https://user-images.githubusercontent.com/50472122/165453643-93282a16-037c-4f97-9d26-8aec3425d14b.png)

![image](https://user-images.githubusercontent.com/50472122/165453665-95a7e373-14c0-40ad-80ec-69b1be3c319d.png)

# 수정 반영 사항

## 모델타입 변화에 따른 수정

<img width="938" alt="image" src="https://user-images.githubusercontent.com/50472122/165454233-ff91c2e8-81b9-435b-bdf2-70e57c89d205.png">

## Assert 변경

<img width="553" alt="reusableCellAssert" src="https://user-images.githubusercontent.com/50472122/165454327-37cb0054-6ddd-4ea4-8268-1888c391dfea.png">

<img width="483" alt="reusableAssert" src="https://user-images.githubusercontent.com/50472122/165454418-e0c6621c-2464-48a0-8f34-ff085c3e0a93.png">

